### PR TITLE
implement first version of eye shaders and update for blender 3.1

### DIFF
--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -45,7 +45,7 @@ class CP77Import(bpy.types.Operator,ImportHelper):
         layout.prop(self, 'image_format')
 
     def execute(self, context):
-        gltf_importer = glTFImporter(self.filepath, { "files": None, "loglevel": 0, "import_pack_images" :True, "merge_vertices" :False, "import_shading" : 'NORMALS', "bone_heuristic":'TEMPERANCE', "guess_original_bind_pose" : False})
+        gltf_importer = glTFImporter(self.filepath, { "files": None, "loglevel": 0, "import_pack_images" :True, "merge_vertices" :False, "import_shading" : 'NORMALS', "bone_heuristic":'TEMPERANCE', "guess_original_bind_pose" : False, "import_user_extensions": ""})
         gltf_importer.read()
         gltf_importer.checks()
 

--- a/i_scene_cp77_gltf/__init__.py
+++ b/i_scene_cp77_gltf/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Cyberpunk 2077 glTF Importer",
-    "author": "HitmanHimself, Turk, Jato",
-    "version": (1, 0, 5),
+    "author": "HitmanHimself, Turk, Jato, dragonzkiller",
+    "version": (1, 0, 6),
     "blender": (3, 0, 0),
     "location": "File > Import-Export",
     "description": "Import WolvenKit Cyberpunk2077 glTF Models With Materials",

--- a/i_scene_cp77_gltf/material_types/eye.py
+++ b/i_scene_cp77_gltf/material_types/eye.py
@@ -10,14 +10,37 @@ class Eye:
     def create(self,Data,Mat):
         CurMat = Mat.node_tree
 
+        if "Specularity" in Data:
+            CurMat.nodes['Principled BSDF'].inputs["Specular"].default_value = Data["Specularity"]
+
+        if "RefractionIndex" in Data:
+            CurMat.nodes['Principled BSDF'].inputs['IOR'].default_value = Data["RefractionIndex"]
+
+#NORMAL/n
         if "Normal" in Data:
             nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["Normal"],-150,-250,'Normal',self.image_format)
             CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
 
+#ROUGHNESS+SCALE/rs
         if "Roughness" in Data:
-            rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Roughness"],-300,0,'Roughness',self.image_format,True)
-            CurMat.links.new(rImgNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+            rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Roughness"],-450,0,'Roughness',self.image_format,True)
 
+        if "RoughnessScale" in Data:
+            rsNode = CreateShaderNodeValue(CurMat, Data["RoughnessScale"],-350,-50,"RoughnessScale")
+
+        # if both nodes were created, scale the image according to the scale factor
+        # then attach the result to the BSDF shader
+        if rImgNode and rsNode:
+            rsVecNode = CurMat.nodes.new("ShaderNodeVectorMath")
+            rsVecNode.location = (-150, 0)
+            rsVecNode.operation = "SCALE"
+            rsVecNode.hide = True
+            
+            CurMat.links.new(rImgNode.outputs[0],rsVecNode.inputs[0])
+            CurMat.links.new(rsNode.outputs[0],rsVecNode.inputs[3])
+            CurMat.links.new(rsVecNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+
+#ALBEDO/a
         if "Albedo" in Data:
             aImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Albedo"],-300,250,'Albedo',self.image_format)
             CurMat.links.new(aImgNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])

--- a/i_scene_cp77_gltf/material_types/eyegradient.py
+++ b/i_scene_cp77_gltf/material_types/eyegradient.py
@@ -2,22 +2,94 @@ import bpy
 import os
 from ..main.common import *
 
+import json
+
 class EyeGradient:
     def __init__(self, BasePath,image_format):
         self.BasePath = BasePath
         self.image_format = image_format
 
     def create(self,Data,Mat):
+
+        # load the gradient profile from the depot
+        file = open(self.BasePath + Data["IrisColorGradient"] + ".json",mode='r')
+        profile = json.loads(file.read())["Data"]["RootChunk"]["Properties"]
+        file.close()
         CurMat = Mat.node_tree
 
+        if "RefractionIndex" in Data:
+            CurMat.nodes['Principled BSDF'].inputs['IOR'].default_value = Data["RefractionIndex"]
+
+        if "Specularity" in Data:
+            CurMat.nodes['Principled BSDF'].inputs["Specular"].default_value = Data["Specularity"]
+
+#NORMAL/n
         if "Normal" in Data:
             nMap = CreateShaderNodeNormalMap(CurMat,self.BasePath + Data["Normal"],-150,-250,'Normal',self.image_format)
             CurMat.links.new(nMap.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Normal'])
 
+#ROUGHNESS+SCALE/rs
         if "Roughness" in Data:
-            rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Roughness"],-300,0,'Roughness',self.image_format,True)
-            CurMat.links.new(rImgNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+            rImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Roughness"],-450,0,'Roughness',self.image_format,True)
 
+        if "RoughnessScale" in Data:
+            rsNode = CreateShaderNodeValue(CurMat, Data["RoughnessScale"],-350,-50,"RoughnessScale")
+
+        # if both nodes were created, scale the image according to the scale factor
+        # then attach the result to the BSDF shader
+        if rImgNode and rsNode:
+            rsVecNode = CurMat.nodes.new("ShaderNodeVectorMath")
+            rsVecNode.location = (-150, 0)
+            rsVecNode.operation = "SCALE"
+            rsVecNode.hide = True
+            
+            CurMat.links.new(rImgNode.outputs[0],rsVecNode.inputs[0])
+            CurMat.links.new(rsNode.outputs[0],rsVecNode.inputs[3])
+            CurMat.links.new(rsVecNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Roughness'])
+
+#ALBEDO/a
         if "Albedo" in Data:
-            aImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Albedo"],-300,250,'Albedo',self.image_format)
+            aImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Albedo"],-550,150,'Albedo',self.image_format)
+
+#IRIS+GRADIENT/igrad
+        if "IrisMask" in Data:
+            iMask = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["IrisMask"],-900,200,'Iris Mask',self.image_format)
+            iMask.image.colorspace_settings.name = 'Non-Color'
+
+        # if we have color gradient data, add a Color Ramp node
+        if "IrisColorGradient" in Data:
+            igradNode = CurMat.nodes.new("ShaderNodeValToRGB")
+            igradNode.location = (-550,500)
+            igradNode.label = "gradientEntries"
+
+            # delete the other nodes and loop through every gradient color entry
+            # (we have to have at least one though)
+            igradNode.color_ramp.elements.remove(igradNode.color_ramp.elements[0])
+            counter = 0
+            for Entry in profile["gradientEntries"]:
+                if counter is 0:
+                    igradNode.color_ramp.elements[0].position = Entry["Properties"].get("value",0)
+                    colr = Entry["Properties"]["color"].get("Properties")
+                    igradNode.color_ramp.elements[0].color = (float(colr["Red"])/255,float(colr["Green"])/255,float(colr["Blue"])/255,float(1))
+                else:
+                    element = igradNode.color_ramp.elements.new(Entry["Properties"].get("value",0))
+                    colr = Entry["Properties"]["color"].get("Properties")
+                    element.color =  (float(colr["Red"])/255,float(colr["Green"])/255,float(colr["Blue"])/255,float(1))
+                counter = counter + 1
+
+        # gradients were successfully created, now connect them together
+        if iMask and igradNode:
+            mixNode = CurMat.nodes.new("ShaderNodeMixRGB")
+            mixNode.blend_type = 'OVERLAY'
+            mixNode.location = (-200,300)
+
+            CurMat.links.new(iMask.outputs[0],igradNode.inputs[0])
+            CurMat.links.new(iMask.outputs[1], mixNode.inputs[0])
+            CurMat.links.new(igradNode.outputs[0], mixNode.inputs[2])
+            CurMat.links.new(aImgNode.outputs[0], mixNode.inputs[1])
+
+            CurMat.links.new(mixNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])
+
+        # fallback to image only if the gradients couldn't be generated
+        else:
             CurMat.links.new(aImgNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])

--- a/i_scene_cp77_gltf/material_types/eyeshadow.py
+++ b/i_scene_cp77_gltf/material_types/eyeshadow.py
@@ -14,8 +14,25 @@ class EyeShadow:
         CurMat.nodes['Principled BSDF'].inputs['Roughness'].default_value = 0.01
         CurMat.nodes['Principled BSDF'].inputs['Transmission'].default_value = 1
 
+#MASK+SHADOW COLOR/ms
         if "Mask" in Data:
-            aImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Mask"],-300,-250,'Mask',self.image_format)
+            mImgNode = CreateShaderNodeTexImage(CurMat,self.BasePath + Data["Mask"],-500,250,'Mask',self.image_format)
+            mImgNode.image.colorspace_settings.name = 'Non-Color'
 
         if "ShadowColor" in Data:
-            shadowColor = CreateShaderNodeRGB(CurMat, Data["ShadowColor"],-450,200,'ShadowColor')
+            msColorNode = CreateShaderNodeRGB(CurMat, Data["ShadowColor"],-400,150,'ShadowColor')
+
+        # if both nodes were created, use the multiply node to mask the shadow
+        # then attach the result to the BSDF shader
+        # since node color is black by default, just use white as the base
+        if mImgNode and msColorNode:
+            mixNode = CurMat.nodes.new("ShaderNodeMixRGB")
+            mixNode.blend_type = 'MULTIPLY'
+            mixNode.location = (-200,200)
+            mixNode.inputs[1].default_value = (1,1,1,1)
+            mixNode.hide = True
+
+            CurMat.links.new(mImgNode.outputs[1],mixNode.inputs[0])
+            CurMat.links.new(msColorNode.outputs[0],mixNode.inputs[2])
+            
+            CurMat.links.new(mixNode.outputs[0],CurMat.nodes['Principled BSDF'].inputs['Base Color'])


### PR DESCRIPTION
First version of gradient eye, gradient eye, and eye shadow shaders. This will require [WolvenKit PR#728](https://github.com/WolvenKit/WolvenKit/pull/728) to function.

There are plenty of other factors to figure out, but this should be a pretty good starting point.